### PR TITLE
added logic to detect different mount point for cgroup

### DIFF
--- a/docker/docker_linux_test.go
+++ b/docker/docker_linux_test.go
@@ -2,7 +2,13 @@
 
 package docker
 
-import "testing"
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+)
 
 func TestGetDockerIDList(t *testing.T) {
 	// If there is not docker environment, this test always fail.
@@ -37,6 +43,35 @@ func TestGetDockerStat(t *testing.T) {
 			}
 		}
 	*/
+}
+
+func TestCgroupMountPoint(t *testing.T) {
+	// see if docker executable is available
+	_, err := exec.LookPath("docker")
+	if err != nil {
+		t.Skip("Docker is not available on this test machine")
+	}
+	b, err := ioutil.ReadFile("/proc/mounts")
+	if err != nil {
+		t.Skip("Current test machine does not have /proc/mounts directory")
+	}
+	content := string(b)
+	found := false
+	targets := []string{"blkio", "cpu", "cpuacct", "cpuset", "devices", "freezer", "hugetlb", "memory", "net_cls", "net_prio", "perf_event", "pids", "systemd"}
+	// if we find any targets that's good
+	for _, target := range targets {
+		mountPoint, err := cgroupMountPoint(target)
+		if err != nil {
+			continue
+		}
+		// test if cgroupMountPoint gets the mount point correctly
+		if strings.Contains(content, fmt.Sprintf("cgroup %s cgroup", mountPoint)) {
+			found = true
+		}
+	}
+	if found == false {
+		t.Errorf("Could not get any cgroup information!")
+	}
 }
 
 func TestCgroupCPU(t *testing.T) {


### PR DESCRIPTION
For cgroups, the configs could be mounted anywhere in the file system. gopsutil assumes that it'll always be in `/sys/fs/cgroup`, which is a false assumption. We should check `/proc/mounts` file and get how all `cgroups` are mounted, then find the config file in there.