### PR TITLE
Drop all docker logic from filled process, revert to upstream.

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -46,7 +46,7 @@ type CgroupMemStat struct {
 	TotalUnevictable        uint64 `json:"totalUnevictable"`
 	MemUsageInBytes         uint64 `json:"memUsageInBytes"`
 	MemMaxUsageInBytes      uint64 `json:"memMaxUsageInBytes"`
-	MemLimitInBytes         uint64 `json:"memoryLimitInBytes"`
+	MemLimitInBytes         uint64 `json:"memoryLimitInBbytes"`
 	MemFailCnt              uint64 `json:"memoryFailcnt"`
 }
 
@@ -56,13 +56,4 @@ type CgroupDockerStat struct {
 	Image       string `json:"image"`
 	Status      string `json:"status"`
 	Running     bool   `json:"running"`
-}
-
-type ContainerStat struct {
-	Type     string  `json:"type"`
-	Name     string  `json:"name"`
-	ID       string  `json:"id"`
-	Image    string  `json:"image"`
-	CPULimit float64 `json:"cpuLimit"`
-	MemLimit uint64  `json:"memLimit"`
 }

--- a/docker/docker_linux.go
+++ b/docker/docker_linux.go
@@ -3,13 +3,11 @@
 package docker
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"os/exec"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 
@@ -54,61 +52,6 @@ func GetDockerStat() ([]CgroupDockerStat, error) {
 	return ret, nil
 }
 
-// Generates a mapping of PIDs to container metadata.
-func GetContainerStatsByPID() (map[int32]ContainerStat, error) {
-	containerMap := make(map[int32]ContainerStat)
-	path, err := cgroupMountPoint("cpuacct")
-	if err != nil {
-		return nil, err
-	}
-	if common.PathExists(path) {
-		contents, err := common.ListDirectory(path)
-		if err != nil {
-			return nil, err
-		}
-
-		// If docker containers exist, collect their stats.
-		if common.StringsContains(contents, "docker") {
-			dockerStats, err := GetDockerStat()
-			if err == nil {
-				for _, dockerStat := range dockerStats {
-					if !dockerStat.Running {
-						continue
-					}
-
-					dockerPids, err := CgroupPIDsDocker(dockerStat.ContainerID)
-					if err != nil {
-						continue
-					}
-					memstat, err := CgroupMemDocker(dockerStat.ContainerID)
-					if err != nil {
-						continue
-					}
-					cpuLimit, err := CgroupCPULimitDocker(dockerStat.ContainerID)
-					if err != nil {
-						continue
-					}
-
-					containerStat := ContainerStat{
-						Type:     "Docker",
-						Name:     dockerStat.Name,
-						ID:       dockerStat.ContainerID,
-						Image:    dockerStat.Image,
-						MemLimit: memstat.MemLimitInBytes,
-						CPULimit: cpuLimit,
-					}
-
-					for _, pid := range dockerPids {
-						containerMap[pid] = containerStat
-					}
-				}
-			}
-		}
-	}
-
-	return containerMap, nil
-}
-
 func (c CgroupDockerStat) String() string {
 	s, _ := json.Marshal(c)
 	return string(s)
@@ -144,10 +87,7 @@ func GetDockerIDList() ([]string, error) {
 // If you use container via systemd.slice, you could use
 // containerID = docker-<container id>.scope and base=/sys/fs/cgroup/cpuacct/system.slice/
 func CgroupCPU(containerID string, base string) (*cpu.TimesStat, error) {
-	statfile, err := getCgroupFilePath(containerID, base, "cpuacct", "cpuacct.stat")
-	if err != nil {
-		return nil, err
-	}
+	statfile := getCgroupFilePath(containerID, base, "cpuacct", "cpuacct.stat")
 	lines, err := common.ReadLines(statfile)
 	if err != nil {
 		return nil, err
@@ -176,97 +116,12 @@ func CgroupCPU(containerID string, base string) (*cpu.TimesStat, error) {
 	return ret, nil
 }
 
-// CgroupCPULimit would show CPU limit for each container
-// it does so by checking the cpu period and cpu quota config
-// if a user does this:
-//
-//	docker run --cpus='0.5' ubuntu:latest
-//
-// we should return 50% for that container
-func CgroupCPULimit(containerID string, base string) (float64, error) {
-	periodFile, err := getCgroupFilePath(containerID, base, "cpu", "cpu.cfs_period_us")
-	if err != nil {
-		return 0.0, err
-	}
-	quotaFile, err := getCgroupFilePath(containerID, base, "cpu", "cpu.cfs_quota_us")
-	if err != nil {
-		return 0.0, err
-	}
-	plines, err := common.ReadLines(periodFile)
-	if err != nil {
-		return 0.0, err
-	}
-	qlines, err := common.ReadLines(quotaFile)
-	if err != nil {
-		return 0.0, err
-	}
-	period, err := strconv.ParseFloat(plines[0], 64)
-	if err != nil {
-		return 0.0, err
-	}
-	quota, err := strconv.ParseFloat(qlines[0], 64)
-	if err != nil {
-		return 0.0, err
-	}
-	// default cpu limit is 100%
-	limit := 100.0
-	if (period > 0) && (quota > 0) {
-		limit = (quota / period) * 100.0
-	}
-	return limit, nil
-}
-
-func CgroupCPULimitDocker(containerID string) (float64, error) {
-	p, err := cgroupMountPoint("cpu")
-	if err != nil {
-		return 0.0, err
-	}
-	return CgroupCPULimit(containerID, filepath.Join(p, "docker"))
-}
-
-func CgroupCPUDocker(containerID string) (*cpu.TimesStat, error) {
-	p, err := cgroupMountPoint("cpuacct")
-	if err != nil {
-		return nil, err
-	}
-	return CgroupCPU(containerID, filepath.Join(p, "docker"))
-}
-
-// CgroupPIDs retrieves the PIDs running within a given container.
-func CgroupPIDs(containerID string, base string) ([]int32, error) {
-	statfile, err := getCgroupFilePath(containerID, base, "cpuacct", "cgroup.procs")
-	if err != nil {
-		return nil, err
-	}
-	lines, err := common.ReadLines(statfile)
-	if err != nil {
-		return nil, err
-	}
-
-	pids := make([]int32, 0, len(lines))
-	for _, line := range lines {
-		pid, err := strconv.Atoi(line)
-		if err == nil {
-			pids = append(pids, int32(pid))
-		}
-	}
-
-	return pids, nil
-}
-
-func CgroupPIDsDocker(containerID string) ([]int32, error) {
-	p, err := cgroupMountPoint("cpuacct")
-	if err != nil {
-		return []int32{}, err
-	}
-	return CgroupPIDs(containerID, filepath.Join(p, "docker"))
+func CgroupCPUDocker(containerid string) (*cpu.TimesStat, error) {
+	return CgroupCPU(containerid, common.HostSys("fs/cgroup/cpuacct/docker"))
 }
 
 func CgroupMem(containerID string, base string) (*CgroupMemStat, error) {
-	statfile, err := getCgroupFilePath(containerID, base, "memory", "memory.stat")
-	if err != nil {
-		return nil, err
-	}
+	statfile := getCgroupFilePath(containerID, base, "memory", "memory.stat")
 
 	// empty containerID means all cgroup
 	if len(containerID) == 0 {
@@ -349,7 +204,7 @@ func CgroupMem(containerID string, base string) (*CgroupMemStat, error) {
 	if err == nil {
 		ret.MemMaxUsageInBytes = r
 	}
-	r, err = getCgroupMemFile(containerID, base, "memory.limit_in_bytes")
+	r, err = getCgroupMemFile(containerID, base, "memoryLimitInBbytes")
 	if err == nil {
 		ret.MemLimitInBytes = r
 	}
@@ -362,11 +217,7 @@ func CgroupMem(containerID string, base string) (*CgroupMemStat, error) {
 }
 
 func CgroupMemDocker(containerID string) (*CgroupMemStat, error) {
-	p, err := cgroupMountPoint("memory")
-	if err != nil {
-		return nil, err
-	}
-	return CgroupMem(containerID, filepath.Join(p, "docker"))
+	return CgroupMem(containerID, common.HostSys("fs/cgroup/memory/docker"))
 }
 
 func (m CgroupMemStat) String() string {
@@ -375,30 +226,23 @@ func (m CgroupMemStat) String() string {
 }
 
 // getCgroupFilePath constructs file path to get targetted stats file.
-func getCgroupFilePath(containerID, base, target, file string) (string, error) {
+func getCgroupFilePath(containerID, base, target, file string) string {
 	if len(base) == 0 {
-		base, _ = cgroupMountPoint(target)
-		base = filepath.Join(base, "docker")
+		base = common.HostSys(fmt.Sprintf("fs/cgroup/%s/docker", target))
 	}
-	statfile := filepath.Join(base, containerID, file)
+	statfile := path.Join(base, containerID, file)
 
 	if _, err := os.Stat(statfile); os.IsNotExist(err) {
-		base, err = cgroupMountPoint(target)
-		if err != nil {
-			return "", err
-		}
-		statfile = filepath.Join(base, "system.slice", fmt.Sprintf("docker-%s.scope", containerID), file)
+		statfile = path.Join(
+			common.HostSys(fmt.Sprintf("fs/cgroup/%s/system.slice", target)), "docker-"+containerID+".scope", file)
 	}
 
-	return statfile, nil
+	return statfile
 }
 
 // getCgroupMemFile reads a cgroup file and return the contents as uint64.
 func getCgroupMemFile(containerID, base, file string) (uint64, error) {
-	statfile, err := getCgroupFilePath(containerID, base, "memory", file)
-	if err != nil {
-		return 0, err
-	}
+	statfile := getCgroupFilePath(containerID, base, "memory", file)
 	lines, err := common.ReadLines(statfile)
 	if err != nil {
 		return 0, err
@@ -406,66 +250,5 @@ func getCgroupMemFile(containerID, base, file string) (uint64, error) {
 	if len(lines) != 1 {
 		return 0, fmt.Errorf("wrong format file: %s", statfile)
 	}
-	v, err := strconv.ParseUint(lines[0], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	// limit_in_bytes is a special case here, it's possible that it shows a ridiculous number,
-	// in which case it represents unlimited, so return 0 here
-	if (file == "memory.limit_in_bytes") && (v > uint64(math.Pow(2, 60))) {
-		v = 0
-	}
-	return v, nil
-}
-
-// function to get the mount point of cgroup. by default it should be under /sys/fs/cgroup but
-// it could be mounted anywhere else if manually defined. Example cgroup entries in /proc/mounts would be
-//	 cgroup /sys/fs/cgroup/cpuset cgroup rw,relatime,cpuset 0 0
-//	 cgroup /sys/fs/cgroup/cpu cgroup rw,relatime,cpu 0 0
-//	 cgroup /sys/fs/cgroup/cpuacct cgroup rw,relatime,cpuacct 0 0
-//	 cgroup /sys/fs/cgroup/memory cgroup rw,relatime,memory 0 0
-//	 cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
-//	 cgroup /sys/fs/cgroup/freezer cgroup rw,relatime,freezer 0 0
-//	 cgroup /sys/fs/cgroup/blkio cgroup rw,relatime,blkio 0 0
-//	 cgroup /sys/fs/cgroup/perf_event cgroup rw,relatime,perf_event 0 0
-//	 cgroup /sys/fs/cgroup/hugetlb cgroup rw,relatime,hugetlb 0 0
-// examples of target would be:
-// blkio  cpu  cpuacct  cpuset  devices  freezer  hugetlb  memory  net_cls  net_prio  perf_event  pids  systemd
-func cgroupMountPoint(target string) (string, error) {
-	file, err := os.Open("/proc/mounts")
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	cgroups := []string{}
-	// get all cgroup entries
-	for scanner.Scan() {
-		text := scanner.Text()
-		if strings.HasPrefix(text, "cgroup ") {
-			cgroups = append(cgroups, text)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	// old cgroup style
-	if len(cgroups) == 1 {
-		tokens := strings.Split(cgroups[0], " ")
-		return tokens[1], nil
-	}
-
-	var candidate string
-	for _, cgroup := range cgroups {
-		tokens := strings.Split(cgroup, " ")
-		// see if the target is the suffix of the mount directory
-		if strings.HasSuffix(tokens[1], target) {
-			candidate = tokens[1]
-		}
-	}
-	if candidate == "" {
-		return candidate, fmt.Errorf("Mount point for cgroup %s is not found!", target)
-	}
-	return candidate, nil
+	return strconv.ParseUint(lines[0], 10, 64)
 }

--- a/docker/docker_linux_test.go
+++ b/docker/docker_linux_test.go
@@ -2,13 +2,7 @@
 
 package docker
 
-import (
-	"fmt"
-	"io/ioutil"
-	"os/exec"
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestGetDockerIDList(t *testing.T) {
 	// If there is not docker environment, this test always fail.
@@ -43,35 +37,6 @@ func TestGetDockerStat(t *testing.T) {
 			}
 		}
 	*/
-}
-
-func TestCgroupMountPoint(t *testing.T) {
-	// see if docker executable is available
-	_, err := exec.LookPath("docker")
-	if err != nil {
-		t.Skip("Docker is not available on this test machine")
-	}
-	b, err := ioutil.ReadFile("/proc/mounts")
-	if err != nil {
-		t.Skip("Current test machine does not have /proc/mounts directory")
-	}
-	content := string(b)
-	found := false
-	targets := []string{"blkio", "cpu", "cpuacct", "cpuset", "devices", "freezer", "hugetlb", "memory", "net_cls", "net_prio", "perf_event", "pids", "systemd"}
-	// if we find any targets that's good
-	for _, target := range targets {
-		mountPoint, err := cgroupMountPoint(target)
-		if err != nil {
-			continue
-		}
-		// test if cgroupMountPoint gets the mount point correctly
-		if strings.Contains(content, fmt.Sprintf("cgroup %s cgroup", mountPoint)) {
-			found = true
-		}
-	}
-	if found == false {
-		t.Errorf("Could not get any cgroup information!")
-	}
 }
 
 func TestCgroupCPU(t *testing.T) {

--- a/process/process.go
+++ b/process/process.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/DataDog/gopsutil/cpu"
-	"github.com/DataDog/gopsutil/docker"
 	"github.com/DataDog/gopsutil/internal/common"
 	"github.com/DataDog/gopsutil/mem"
 )
@@ -42,7 +41,6 @@ type FilledProcess struct {
 	CpuTime2    *cpu.TimesStat
 	Nice        int32
 	CreateTime  int64
-	Container   docker.ContainerStat
 	OpenFdCount int32
 
 	// status


### PR DESCRIPTION
We're moving all the docker stuff into our own repo in order to use it elsewhere and have better control on it. This also allows us to remove Docker from the filled process and to revert the `docker` package changes back to the upstream state.

Going forward we should not use `gopsutil/docker` but have this code in our Agent. See https://github.com/DataDog/dd-process-agent/pull/11