### PR TITLE
Remove sleep from AllProcesses, just collect current CPU time

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -37,8 +37,7 @@ type FilledProcess struct {
 	Cmdline []string
 	// stat
 	Pgrp        int32
-	CpuTime1    *cpu.TimesStat
-	CpuTime2    *cpu.TimesStat
+	CpuTime     cpu.TimesStat
 	Nice        int32
 	CreateTime  int64
 	OpenFdCount int32

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -880,7 +880,7 @@ func collectFilled(pids []int32, concurrency int) map[int32]*FilledProcess {
 				Cmdline: cmdline,
 				// stat
 				Pgrp:        pgrp,
-				CpuTime1:    t1,
+				CpuTime:     *t1,
 				Nice:        nice,
 				CreateTime:  createTime,
 				OpenFdCount: openFdCount,
@@ -917,57 +917,10 @@ func collectFilled(pids []int32, concurrency int) map[int32]*FilledProcess {
 	return procs
 }
 
-func collectTimes(pids []int32, concurrency int) map[int32]*cpu.TimesStat {
-	sem := make(chan bool, concurrency)
-	timesAfter := make(chan cpuAfter, len(pids))
-	for _, pid := range pids {
-		sem <- true
-		go func(pid int32) {
-			defer func() { <-sem }()
-			p, err := NewProcess(pid)
-			if err != nil {
-				timesAfter <- cpuAfter{pid, nil, fmt.Errorf("pid: %s", err)}
-				return
-			}
-			_, _, t2, _, _, err := p.fillFromStat()
-			if err != nil {
-				timesAfter <- cpuAfter{pid, nil, fmt.Errorf("stat2: %s", err)}
-				return
-			}
-			timesAfter <- cpuAfter{pid, t2, nil}
-		}(pid)
-	}
-
-	for i := 0; i < cap(sem); i++ {
-		sem <- true
-	}
-	times := make(map[int32]*cpu.TimesStat)
-	for i := 0; i < len(pids); i++ {
-		t := <-timesAfter
-		if t.err != nil {
-			// log the error?
-			continue
-		}
-		times[t.pid] = t.t
-	}
-	return times
-}
-
-func AllProcesses(cpuWait time.Duration, concurrency int) ([]*FilledProcess, error) {
+func AllProcesses(cpuWait time.Duration, concurrency int) (map[int32]*FilledProcess, error) {
 	pids, err := Pids()
 	if err != nil {
 		return nil, fmt.Errorf("could not collect pids: %s", err)
 	}
-	procsByPid := collectFilled(pids, concurrency)
-	time.Sleep(cpuWait)
-	timesByPid := collectTimes(pids, concurrency)
-
-	procs := make([]*FilledProcess, 0, len(procsByPid))
-	for pid, p := range procsByPid {
-		if t, ok := timesByPid[pid]; ok {
-			p.CpuTime2 = t
-			procs = append(procs, p)
-		}
-	}
-	return procs, nil
+	return collectFilled(pids, concurrency), nil
 }


### PR DESCRIPTION
We'll move the calculation against the previous CPU time to the user's side.