### PR TITLE
Mac support for AllProcesses()

### DIFF
--- a/cpu/cpu_darwin_cgo.go
+++ b/cpu/cpu_darwin_cgo.go
@@ -8,7 +8,10 @@ package cpu
 #include <sys/sysctl.h>
 #include <sys/mount.h>
 #include <mach/mach_init.h>
+#ifndef TEST_H_
+#define TEST_H_
 #include <mach/mach_host.h>
+#endif
 #include <mach/host_info.h>
 #if TARGET_OS_MAC
 #include <libproc.h>

--- a/mem/mem_darwin_cgo.go
+++ b/mem/mem_darwin_cgo.go
@@ -4,7 +4,10 @@
 package mem
 
 /*
+#ifndef TEST_H_
+#define TEST_H_
 #include <mach/mach_host.h>
+#endif
 */
 import "C"
 

--- a/process/process.go
+++ b/process/process.go
@@ -36,7 +36,6 @@ type FilledProcess struct {
 	Ppid    int32
 	Cmdline []string
 	// stat
-	Pgrp        int32
 	CpuTime     cpu.TimesStat
 	Nice        int32
 	CreateTime  int64
@@ -68,6 +67,17 @@ type MemoryInfoStat struct {
 	RSS  uint64 `json:"rss"`  // bytes
 	VMS  uint64 `json:"vms"`  // bytes
 	Swap uint64 `json:"swap"` // bytes
+}
+
+// MemoryInfoExStat is different between OSes
+type MemoryInfoExStat struct {
+	RSS    uint64 `json:"rss"`    // bytes
+	VMS    uint64 `json:"vms"`    // bytes
+	Shared uint64 `json:"shared"` // bytes
+	Text   uint64 `json:"text"`   // bytes
+	Lib    uint64 `json:"lib"`    // bytes
+	Data   uint64 `json:"data"`   // bytes
+	Dirty  uint64 `json:"dirty"`  // bytes
 }
 
 type RlimitStat struct {

--- a/process/process_fallback.go
+++ b/process/process_fallback.go
@@ -24,9 +24,6 @@ type MemoryMapsStat struct {
 	Swap         uint64 `json:"swap"`
 }
 
-type MemoryInfoExStat struct {
-}
-
 func Pids() ([]int32, error) {
 	return []int32{}, common.ErrNotImplementedError
 }

--- a/process/process_freebsd.go
+++ b/process/process_freebsd.go
@@ -13,10 +13,6 @@ import (
 	net "github.com/DataDog/gopsutil/net"
 )
 
-// MemoryInfoExStat is different between OSes
-type MemoryInfoExStat struct {
-}
-
 type MemoryMapsStat struct {
 }
 

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -32,22 +32,6 @@ const (
 	ClockTicks  = 100 // C.sysconf(C._SC_CLK_TCK)
 )
 
-// MemoryInfoExStat is different between OSes
-type MemoryInfoExStat struct {
-	RSS    uint64 `json:"rss"`    // bytes
-	VMS    uint64 `json:"vms"`    // bytes
-	Shared uint64 `json:"shared"` // bytes
-	Text   uint64 `json:"text"`   // bytes
-	Lib    uint64 `json:"lib"`    // bytes
-	Data   uint64 `json:"data"`   // bytes
-	Dirty  uint64 `json:"dirty"`  // bytes
-}
-
-func (m MemoryInfoExStat) String() string {
-	s, _ := json.Marshal(m)
-	return string(s)
-}
-
 type MemoryMapsStat struct {
 	Path         string `json:"path"`
 	Rss          uint64 `json:"rss"`
@@ -836,7 +820,7 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 		if err != nil {
 			continue
 		}
-		ppid, pgrp, t1, createTime, nice, err := p.fillFromStat()
+		ppid, _, t1, createTime, nice, err := p.fillFromStat()
 		if err != nil {
 			continue
 		}
@@ -867,7 +851,6 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			Ppid:    ppid,
 			Cmdline: cmdline,
 			// stat
-			Pgrp:        pgrp,
 			CpuTime:     *t1,
 			Nice:        nice,
 			CreateTime:  createTime,

--- a/process/process_openbsd.go
+++ b/process/process_openbsd.go
@@ -3,8 +3,8 @@
 package process
 
 import (
-	"bytes"
 	"C"
+	"bytes"
 	"encoding/binary"
 	"strings"
 	"syscall"
@@ -12,13 +12,9 @@ import (
 
 	cpu "github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/internal/common"
-	net "github.com/DataDog/gopsutil/net"
 	mem "github.com/DataDog/gopsutil/mem"
+	net "github.com/DataDog/gopsutil/net"
 )
-
-// MemoryInfoExStat is different between OSes
-type MemoryInfoExStat struct {
-}
 
 type MemoryMapsStat struct {
 }
@@ -58,7 +54,7 @@ func (p *Process) Exe() (string, error) {
 }
 
 func (p *Process) CmdlineSlice() ([]string, error) {
-	mib := []int32{CTLKern, KernProcArgs, p.Pid, KernProcArgv }
+	mib := []int32{CTLKern, KernProcArgs, p.Pid, KernProcArgv}
 	buf, _, err := common.CallSyscall(mib)
 
 	if err != nil {
@@ -75,7 +71,7 @@ func (p *Process) CmdlineSlice() ([]string, error) {
 		strParts = append(strParts, C.GoString(argv))
 
 		argc++
-		argv = *(**C.char)(unsafe.Pointer(uintptr(argvp) + uintptr(argc) * size))
+		argv = *(**C.char)(unsafe.Pointer(uintptr(argvp) + uintptr(argc)*size))
 	}
 	return strParts, nil
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -43,10 +43,6 @@ type SystemProcessInformation struct {
 	Reserved6         [6]uint64
 }
 
-// Memory_info_ex is different between OSes
-type MemoryInfoExStat struct {
-}
-
 type MemoryMapsStat struct {
 }
 


### PR DESCRIPTION
Add `AllProcesses` in the process_darwin file and add some minor modifications for:

* Limiting syscalls and sharing some logic (e.g. formatting times)
* Changing the `ps` call arguments so we get the full command
* Some bits of style and `gofmt` where it wasn't run.