### PR TITLE
[win] Switch back to using QuotaPagedPoolUsage for VMS

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -530,7 +530,7 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			CtxSwitches: &NumCtxSwitchesStat{},
 			MemInfo: &MemoryInfoStat{
 				RSS:  pmemcounter.WorkingSetSize,
-				VMS:  pmemcounter.PagefileUsage,
+				VMS:  pmemcounter.QuotaPagedPoolUsage,
 				Swap: 0, // it's unclear there's a Windows measurement of swap file usage
 			},
 			//Cwd


### PR DESCRIPTION
@derekwbrown Could you confirm this is the right memory counter to have the windows process memory match what is in the TaskManager? 