### PR TITLE
Add a check on the length of fields before trying to access the first…

### DIFF
--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -198,6 +198,10 @@ func Info() ([]InfoStat, error) {
 func parseStatLine(line string) (*TimesStat, error) {
 	fields := strings.Fields(line)
 
+	if len(fields) == 0 {
+		return nil, errors.New("no stats found")
+	}
+
 	if strings.HasPrefix(fields[0], "cpu") == false {
 		//		return CPUTimesStat{}, e
 		return nil, errors.New("not contain cpu")


### PR DESCRIPTION
Fix Parse stat line panic when fields length is 0.

https://trello.com/c/01ggWRc3/1125-crash-on-invalid-proc-path

@DataDog/burrito