### PR TITLE
Ensure that restricted procfs files can be opened before opening them

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -49,6 +49,11 @@ type MemoryMapsStat struct {
 	Swap         uint64 `json:"swap"`
 }
 
+type currentUser struct {
+	uid  uint32
+	euid uint32
+}
+
 // String returns JSON value of the process.
 func (m MemoryMapsStat) String() string {
 	s, _ := json.Marshal(m)
@@ -89,7 +94,7 @@ func (p *Process) Name() (string, error) {
 
 // Exe returns executable path of the process.
 func (p *Process) Exe() (string, error) {
-	return p.fillFromExe()
+	return p.fillFromExe(getCurrentUser())
 }
 
 // Cmdline returns the command line arguments of the process as a string with
@@ -115,7 +120,7 @@ func (p *Process) CreateTime() (int64, error) {
 
 // Cwd returns current working directory of the process.
 func (p *Process) Cwd() (string, error) {
-	return p.fillFromCwd()
+	return p.fillFromCwd(getCurrentUser())
 }
 
 // Parent returns parent Process of the process.
@@ -192,7 +197,7 @@ func (p *Process) Rlimit() ([]RlimitStat, error) {
 
 // IOCounters returns IO Counters.
 func (p *Process) IOCounters() (*IOCountersStat, error) {
-	return p.fillFromIO()
+	return p.fillFromIO(getCurrentUser())
 }
 
 // NumCtxSwitches returns the number of the context switches of the process.
@@ -206,7 +211,7 @@ func (p *Process) NumCtxSwitches() (*NumCtxSwitchesStat, error) {
 
 // NumFDs returns the number of File Descriptors used by the process.
 func (p *Process) NumFDs() (int32, error) {
-	_, fds, err := p.fillFromfdList()
+	_, fds, err := p.fillFromfdList(getCurrentUser())
 	return int32(len(fds)), err
 }
 
@@ -284,7 +289,7 @@ func (p *Process) Children() ([]*Process, error) {
 // OpenFiles returns a slice of OpenFilesStat opend by the process.
 // OpenFilesStat includes a file path and file descriptor.
 func (p *Process) OpenFiles() ([]OpenFilesStat, error) {
-	_, ofs, err := p.fillFromfd()
+	_, ofs, err := p.fillFromfd(getCurrentUser())
 	if err != nil {
 		return nil, err
 	}
@@ -397,11 +402,11 @@ func (p *Process) MemoryMaps(grouped bool) (*[]MemoryMapsStat, error) {
 **/
 
 // Get list of /proc/(pid)/fd files
-func (p *Process) fillFromfdList() (string, []string, error) {
+func (p *Process) fillFromfdList(user *currentUser) (string, []string, error) {
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "fd")
 
-	if err := ensurePathReadable(statPath); err != nil {
+	if err := ensurePathReadable(statPath, user); err != nil {
 		return statPath, []string{}, err
 	}
 
@@ -415,8 +420,8 @@ func (p *Process) fillFromfdList() (string, []string, error) {
 }
 
 // Get num_fds from /proc/(pid)/fd
-func (p *Process) fillFromfd() (int32, []*OpenFilesStat, error) {
-	statPath, fnames, err := p.fillFromfdList()
+func (p *Process) fillFromfd(user *currentUser) (int32, []*OpenFilesStat, error) {
+	statPath, fnames, err := p.fillFromfdList(user)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -444,10 +449,10 @@ func (p *Process) fillFromfd() (int32, []*OpenFilesStat, error) {
 }
 
 // Get cwd from /proc/(pid)/cwd
-func (p *Process) fillFromCwd() (string, error) {
+func (p *Process) fillFromCwd(user *currentUser) (string, error) {
 	pid := p.Pid
 	cwdPath := common.HostProc(strconv.Itoa(int(pid)), "cwd")
-	if err := ensurePathReadable(cwdPath); err != nil {
+	if err := ensurePathReadable(cwdPath, user); err != nil {
 		return "", err
 	}
 	cwd, err := os.Readlink(cwdPath)
@@ -458,10 +463,10 @@ func (p *Process) fillFromCwd() (string, error) {
 }
 
 // Get exe from /proc/(pid)/exe
-func (p *Process) fillFromExe() (string, error) {
+func (p *Process) fillFromExe(user *currentUser) (string, error) {
 	pid := p.Pid
 	exePath := common.HostProc(strconv.Itoa(int(pid)), "exe")
-	if err := ensurePathReadable(exePath); err != nil {
+	if err := ensurePathReadable(exePath, user); err != nil {
 		return "", err
 	}
 	exe, err := os.Readlink(exePath)
@@ -512,11 +517,11 @@ func (p *Process) fillSliceFromCmdline() ([]string, error) {
 }
 
 // Get IO status from /proc/(pid)/io
-func (p *Process) fillFromIO() (*IOCountersStat, error) {
+func (p *Process) fillFromIO(user *currentUser) (*IOCountersStat, error) {
 	pid := p.Pid
 	ioPath := common.HostProc(strconv.Itoa(int(pid)), "io")
 
-	if err := ensurePathReadable(ioPath); err != nil {
+	if err := ensurePathReadable(ioPath, user); err != nil {
 		return nil, err
 	}
 
@@ -816,6 +821,7 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 		return nil, fmt.Errorf("could not collect pids: %s", err)
 	}
 
+	user := getCurrentUser()
 	// Collect stats on all processes limiting the number of required syscalls.
 	// All errors are swallowed for now.
 	procs := make(map[int32]*FilledProcess)
@@ -840,7 +846,7 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			memInfo = &MemoryInfoStat{}
 			memInfoEx = &MemoryInfoExStat{}
 		}
-		ioStat, err := p.fillFromIO()
+		ioStat, err := p.fillFromIO(user)
 		if os.IsPermission(err) {
 			log.Debugf("Unable to access /proc/%d/io, permission denied", pid)
 			// Without root permissions we can't read for other processes.
@@ -854,7 +860,7 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			log.Debugf("Unable to fill from /proc/%d/stat: %s", pid, err)
 			t1 = &cpu.TimesStat{}
 		}
-		cwd, err := p.fillFromCwd()
+		cwd, err := p.fillFromCwd(user)
 		if os.IsPermission(err) {
 			log.Debugf("Unable to access /proc/%d/cwd, permission denied", pid)
 			cwd = ""
@@ -862,7 +868,7 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			log.Debugf("Unable to access /proc/%d/cwd: %s", pid, err)
 			cwd = ""
 		}
-		exe, err := p.fillFromExe()
+		exe, err := p.fillFromExe(user)
 		if os.IsPermission(err) {
 			// Without root permissions we can't read for other processes.
 			log.Debugf("Unable to access /proc/%d/exe, permission denied", pid)
@@ -871,14 +877,15 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			log.Debugf("Unable to access /proc/%d/exe: %s", pid, err)
 			exe = ""
 		}
-		openFdCount, err := p.NumFDs()
+		openFdCount := int32(-1)
+		_, fds, err := p.fillFromfdList(user)
 		if os.IsPermission(err) {
 			// Without root permissions we can't read for other processes.
 			log.Debugf("Unable to access /proc/%d/fd, permission denied", pid)
-			openFdCount = -1
 		} else if err != nil {
 			log.Debugf("Unable to access /proc/%d/fd: %s", pid, err)
-			openFdCount = -1
+		} else {
+			openFdCount = int32(len(fds))
 		}
 
 		procs[p.Pid] = &FilledProcess{
@@ -912,14 +919,19 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 	return procs, nil
 }
 
+func getCurrentUser() *currentUser {
+	return &currentUser{
+		uid:  uint32(os.Getuid()),
+		euid: uint32(os.Geteuid()),
+	}
+}
+
 // ensurePathReadable ensures that the current user is able to read the path in question
 // before opening it.  on some systems, attempting to open a file that the user does
 // not have permission is problematic for customer security auditing
-func ensurePathReadable(path string) error {
-	euid := uint32(os.Geteuid())
-
+func ensurePathReadable(path string, user *currentUser) error {
 	// User is (effectively or actually) root
-	if euid == 0 {
+	if user.euid == 0 {
 		return nil
 	}
 
@@ -935,11 +947,9 @@ func ensurePathReadable(path string) error {
 	}
 
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		uid := uint32(os.Getuid())
-
 		// If file is not owned by the user id or effective user id, return a permission error
 		// Group permissions don't come in to play with procfs so we don't bother checking
-		if stat.Uid != uid && stat.Uid != euid {
+		if stat.Uid != user.uid && stat.Uid != user.euid {
 			return os.ErrPermission
 		}
 	}


### PR DESCRIPTION
On systems that track failed syscalls via strace or some other mechanism, our agent can generate a lot of errors due to the following files usually being inaccessible to the agent:

- /proc/[pid]/cwd
- /proc/[pid]/exe
- /proc/[pid]/fd
- /proc/[pid]/io

Running strace on the agent, you can see errors like

```
[pid 14745] readlinkat(AT_FDCWD, "/proc/1/cwd", 0xc42058f900, 128) = -1 EACCES (Permission denied)
[pid 14745] readlinkat(AT_FDCWD, "/proc/1/exe", 0xc42058f980, 128) = -1 EACCES (Permission denied)
[pid 14745] openat(AT_FDCWD, "/proc/7/fd", O_RDONLY|O_CLOEXEC) = -1 EACCES (Permission denied)
[pid 14745] openat(AT_FDCWD, "/proc/8/io", O_RDONLY|O_CLOEXEC) = -1 EACCES (Permission denied)
```

This PR modifies the lookup path for those 4 procfs files to ensure that they are readable by the agent before opening them.  The logic is

- If the agent is running as root (real or via sudo), allow the request
- If the file is a not a symlink and has the other-readable permission bit set, allow the request
    - The _fd_ and _io_ procfs entries are files, the _exe_ and _cwd_ entries are symlinks
    - Symlinks will always have the readable bit set so we can't rely on that here.
- Finally, if the owner of the file/link is the current user or effective user, allow the request.

From what I've seen, unix groups don't come in to play with procfs so I'm not taking them in to account.  There may also be other capability based mechanisms to check the permissions but I'm not aware of using them to read procfs

These checks do introduce some additional performance penalties.  There are new syscalls to:

- Read the current user id
- Read the effective user id
- Lstat the path in question

I'm not sure if the results of the first two calls should be cached but that could be an option here.  All in all, I think the impact should be neglible given that the checks are only scoped to those files.  

I considered seeing if this behavior could be toggled but I didn't see a way to add feature toggles to our fork here. 

cc: @DataDog/burrito 