### PR TITLE
procs: Ensure that IOStat, CtxSwitches and MemInfoEx are not nil on darwin

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -58,7 +58,7 @@ type FilledProcess struct {
 	// IO
 	IOStat *IOCountersStat
 	// Username (windows only)
-	Username	string
+	Username string
 }
 
 type OpenFilesStat struct {

--- a/process/process_darwin.go
+++ b/process/process_darwin.go
@@ -584,6 +584,10 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 				VMS:  uint64(vms) * 1024,
 				Swap: uint64(pagein),
 			},
+			// Unsupported stats
+			IOStat:      &IOCountersStat{},
+			CtxSwitches: &NumCtxSwitchesStat{},
+			MemInfoEx:   &MemoryInfoExStat{},
 		}
 	}
 


### PR DESCRIPTION
This is to avoid panics on the process-agent on darwin when trying to access those fields