### PR TITLE
Explicitly type RSS and VMS values

### DIFF
--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -529,8 +529,8 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 			NumThreads:  int32(pe32.CntThreads),
 			CtxSwitches: &NumCtxSwitchesStat{},
 			MemInfo: &MemoryInfoStat{
-				RSS:  pmemcounter.WorkingSetSize,
-				VMS:  pmemcounter.PagefileUsage,
+				RSS:  uint64(pmemcounter.WorkingSetSize),
+				VMS:  uint64(pmemcounter.PagefileUsage),
 				Swap: 0, // it's unclear there's a Windows measurement of swap file usage
 			},
 			//Cwd


### PR DESCRIPTION
Explicitly cast values from pmemcounter up to 64 bit.  On 64 bit OS< this is a noop.  On 32 bit, casting up should not have any negative consequence