### PR TITLE
Check if path exists and is nonempty before reading host files

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -342,6 +342,8 @@ func PlatformInformation() (platform string, family string, version string, err 
 		version = lsb.Release
 	}
 
+	platform = strings.Trim(platform, "\"")
+
 	switch platform {
 	case "debian", "ubuntu", "linuxmint", "raspbian":
 		family = "debian"

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -189,7 +189,7 @@ func getOSRelease() (platform string, version string, err error) {
 
 func getLSB() (*LSB, error) {
 	ret := &LSB{}
-	if common.PathExists(common.HostEtc("lsb-release")) {
+	if common.PathExistsWithContents(common.HostEtc("lsb-release")) {
 		contents, err := common.ReadLines(common.HostEtc("lsb-release"))
 		if err != nil {
 			return ret, err // return empty
@@ -210,7 +210,7 @@ func getLSB() (*LSB, error) {
 				ret.Description = field[1]
 			}
 		}
-	} else if common.PathExists("/usr/bin/lsb_release") {
+	} else if common.PathExistsWithContents("/usr/bin/lsb_release") {
 		lsb_release, err := exec.LookPath("/usr/bin/lsb_release")
 		if err != nil {
 			return ret, err
@@ -248,26 +248,26 @@ func PlatformInformation() (platform string, family string, version string, err 
 		lsb = &LSB{}
 	}
 
-	if common.PathExists(common.HostEtc("oracle-release")) {
+	if common.PathExistsWithContents(common.HostEtc("oracle-release")) {
 		platform = "oracle"
 		contents, err := common.ReadLines(common.HostEtc("oracle-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 		}
 
-	} else if common.PathExists(common.HostEtc("enterprise-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("enterprise-release")) {
 		platform = "oracle"
 		contents, err := common.ReadLines(common.HostEtc("enterprise-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 		}
-	} else if common.PathExists(common.HostEtc("slackware-version")) {
+	} else if common.PathExistsWithContents(common.HostEtc("slackware-version")) {
 		platform = "slackware"
 		contents, err := common.ReadLines(common.HostEtc("slackware-version"))
 		if err == nil {
 			version = getSlackwareVersion(contents)
 		}
-	} else if common.PathExists(common.HostEtc("debian_version")) {
+	} else if common.PathExistsWithContents(common.HostEtc("debian_version")) {
 		if lsb.ID == "Ubuntu" {
 			platform = "ubuntu"
 			version = lsb.Release
@@ -275,7 +275,7 @@ func PlatformInformation() (platform string, family string, version string, err 
 			platform = "linuxmint"
 			version = lsb.Release
 		} else {
-			if common.PathExists("/usr/bin/raspi-config") {
+			if common.PathExistsWithContents("/usr/bin/raspi-config") {
 				platform = "raspbian"
 			} else {
 				platform = "debian"
@@ -285,41 +285,41 @@ func PlatformInformation() (platform string, family string, version string, err 
 				version = contents[0]
 			}
 		}
-	} else if common.PathExists(common.HostEtc("redhat-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("redhat-release")) {
 		contents, err := common.ReadLines(common.HostEtc("redhat-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 			platform = getRedhatishPlatform(contents)
 		}
-	} else if common.PathExists(common.HostEtc("system-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("system-release")) {
 		contents, err := common.ReadLines(common.HostEtc("system-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 			platform = getRedhatishPlatform(contents)
 		}
-	} else if common.PathExists(common.HostEtc("gentoo-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("gentoo-release")) {
 		platform = "gentoo"
 		contents, err := common.ReadLines(common.HostEtc("gentoo-release"))
 		if err == nil {
 			version = getRedhatishVersion(contents)
 		}
-	} else if common.PathExists(common.HostEtc("SuSE-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("SuSE-release")) {
 		contents, err := common.ReadLines(common.HostEtc("SuSE-release"))
 		if err == nil {
 			version = getSuseVersion(contents)
 			platform = getSusePlatform(contents)
 		}
 		// TODO: slackware detecion
-	} else if common.PathExists(common.HostEtc("arch-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("arch-release")) {
 		platform = "arch"
 		version = lsb.Release
-	} else if common.PathExists(common.HostEtc("alpine-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("alpine-release")) {
 		platform = "alpine"
 		contents, err := common.ReadLines(common.HostEtc("alpine-release"))
 		if err == nil && len(contents) > 0 {
 			version = contents[0]
 		}
-	} else if common.PathExists(common.HostEtc("os-release")) {
+	} else if common.PathExistsWithContents(common.HostEtc("os-release")) {
 		p, v, err := getOSRelease()
 		if err == nil {
 			platform = p

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -285,6 +285,25 @@ func PathExists(filename string) bool {
 	return false
 }
 
+func PathExistsWithContents(filename string) bool {
+	if _, err := os.Stat(filename); err != nil {
+		return false
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+	_, err = r.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 //GetEnv retrieves the environment variable key. If it does not exist it returns the default.
 func GetEnv(key string, dfault string, combineWith ...string) string {
 	value := os.Getenv(key)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -297,7 +297,7 @@ func PathExistsWithContents(filename string) bool {
 	defer f.Close()
 
 	r := bufio.NewReader(f)
-	_, err = r.ReadString('\n')
+	_, err = r.ReadSlice('\n')
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
When we mount the required `/etc` files for host detection to a container, whenever a file isn't present on the host we end up creating an empty file in that location in the container. This can break host OS detection, so we need to make sure that when we check if a file exists, we also check that it contains data.