### PR TITLE
[Process] fix cmdline cuteset

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package process
@@ -618,9 +619,7 @@ func (p *Process) fillSliceFromCmdline() ([]string, error) {
 	if len(cmdline) == 0 {
 		return nil, nil
 	}
-	if cmdline[len(cmdline)-1] == 0 {
-		cmdline = cmdline[:len(cmdline)-1]
-	}
+	cmdline = bytes.TrimRight(cmdline, "\x00")
 	parts := bytes.Split(cmdline, []byte{0})
 	var strParts []string
 	for _, p := range parts {


### PR DESCRIPTION
What does this PR do ?
-----------------------

This PR fixes a parsing bug in the `fillSliceFromCmdline()` function.

In some edge cases, `/proc/[pid]/cmdline` returns a buffer with more than one trailing `\x00` (this is the case for the subprocesses of a `postgres` database). The current function trims the ending `\x00` only, thus introducing empty strings in the returned list of arguments. This PR proposes to remove all trailing `\x00` so that `fillSliceFromCmdline()` returns the exact number of arguments.