### PR TITLE
[macOS M1] Backports from upstream to fix cpu.Info() crashes

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -69,10 +69,9 @@ func Info() ([]InfoStat, error) {
 	// Use the rated frequency of the CPU. This is a static value and does not
 	// account for low power or Turbo Boost modes.
 	cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency")
-	if err != nil {
-		return ret, err
+	if err == nil {
+		c.Mhz = float64(cpuFrequency) / 1000000.0
 	}
-	c.Mhz = float64(cpuFrequency) / 1000000.0
 
 	return append(ret, c), nil
 }

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -3,9 +3,10 @@
 package cpu
 
 import (
-	"os/exec"
 	"strconv"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // sys/resource.h
@@ -32,75 +33,46 @@ func Times(percpu bool) ([]TimesStat, error) {
 // Returns only one CPUInfoStat on FreeBSD
 func Info() ([]InfoStat, error) {
 	var ret []InfoStat
-	sysctl, err := exec.LookPath("/usr/sbin/sysctl")
-	if err != nil {
-		return ret, err
-	}
-	out, err := invoke.Command(sysctl, "machdep.cpu")
-	if err != nil {
-		return ret, err
-	}
 
 	c := InfoStat{}
-	for _, line := range strings.Split(string(out), "\n") {
-		values := strings.Fields(line)
-		if len(values) < 1 {
-			continue
-		}
-
-		t, err := strconv.ParseInt(values[1], 10, 64)
-		// err is not checked here because some value is string.
-		if strings.HasPrefix(line, "machdep.cpu.brand_string") {
-			c.ModelName = strings.Join(values[1:], " ")
-		} else if strings.HasPrefix(line, "machdep.cpu.family") {
-			c.Family = values[1]
-		} else if strings.HasPrefix(line, "machdep.cpu.model") {
-			c.Model = values[1]
-		} else if strings.HasPrefix(line, "machdep.cpu.stepping") {
-			if err != nil {
-				return ret, err
-			}
-			c.Stepping = int32(t)
-		} else if strings.HasPrefix(line, "machdep.cpu.features") {
-			for _, v := range values[1:] {
-				c.Flags = append(c.Flags, strings.ToLower(v))
-			}
-		} else if strings.HasPrefix(line, "machdep.cpu.leaf7_features") {
-			for _, v := range values[1:] {
-				c.Flags = append(c.Flags, strings.ToLower(v))
-			}
-		} else if strings.HasPrefix(line, "machdep.cpu.extfeatures") {
-			for _, v := range values[1:] {
-				c.Flags = append(c.Flags, strings.ToLower(v))
-			}
-		} else if strings.HasPrefix(line, "machdep.cpu.core_count") {
-			if err != nil {
-				return ret, err
-			}
-			c.Cores = int32(t)
-		} else if strings.HasPrefix(line, "machdep.cpu.cache.size") {
-			if err != nil {
-				return ret, err
-			}
-			c.CacheSize = int32(t)
-		} else if strings.HasPrefix(line, "machdep.cpu.vendor") {
-			c.VendorID = values[1]
+	c.ModelName, _ = unix.Sysctl("machdep.cpu.brand_string")
+	family, _ := unix.SysctlUint32("machdep.cpu.family")
+	c.Family = strconv.FormatUint(uint64(family), 10)
+	model, _ := unix.SysctlUint32("machdep.cpu.model")
+	c.Model = strconv.FormatUint(uint64(model), 10)
+	stepping, _ := unix.SysctlUint32("machdep.cpu.stepping")
+	c.Stepping = int32(stepping)
+	features, err := unix.Sysctl("machdep.cpu.features")
+	if err == nil {
+		for _, v := range strings.Fields(features) {
+			c.Flags = append(c.Flags, strings.ToLower(v))
 		}
 	}
+	leaf7Features, err := unix.Sysctl("machdep.cpu.leaf7_features")
+	if err == nil {
+		for _, v := range strings.Fields(leaf7Features) {
+			c.Flags = append(c.Flags, strings.ToLower(v))
+		}
+	}
+	extfeatures, err := unix.Sysctl("machdep.cpu.extfeatures")
+	if err == nil {
+		for _, v := range strings.Fields(extfeatures) {
+			c.Flags = append(c.Flags, strings.ToLower(v))
+		}
+	}
+	cores, _ := unix.SysctlUint32("machdep.cpu.core_count")
+	c.Cores = int32(cores)
+	cacheSize, _ := unix.SysctlUint32("machdep.cpu.cache.size")
+	c.CacheSize = int32(cacheSize)
+	c.VendorID, _ = unix.Sysctl("machdep.cpu.vendor")
 
 	// Use the rated frequency of the CPU. This is a static value and does not
 	// account for low power or Turbo Boost modes.
-	out, err = invoke.Command(sysctl, "hw.cpufrequency")
+	cpuFrequency, err := unix.SysctlUint64("hw.cpufrequency")
 	if err != nil {
 		return ret, err
 	}
-
-	values := strings.Fields(string(out))
-	hz, err := strconv.ParseFloat(values[1], 64)
-	if err != nil {
-		return ret, err
-	}
-	c.Mhz = hz / 1000000.0
+	c.Mhz = float64(cpuFrequency) / 1000000.0
 
 	return append(ret, c), nil
 }


### PR DESCRIPTION
Since https://github.com/DataDog/gopsutil/pull/40, we can build projects containing this `gopsutil` fork on macOS M1.

However, using `cpu.Info()` causes a crash: `sysctl hw.cpufrequency` doesn't return anything on M1, which makes the following snippet crash:
```
out, err = invoke.Command(sysctl, "hw.cpufrequency")
	if err != nil {
		return ret, err
	}

	values := strings.Fields(string(out))
	hz, err := strconv.ParseFloat(values[1], 64)
```

with an index out-of-range error.

This PR:
- backports https://github.com/Lomanic/gopsutil/commit/2ec35609d2152d006db9bf7d6cd278d37ab01dae, which uses `golang.org/x/sys/unix.Sysctl` instead of manual calls to the `sysctl` binary, preventing the crash
- backports https://github.com/shirou/gopsutil/pull/1192 to not make `cpu.Info()` return an error when the CPU frequency cannot be found, to prevent the method from erroring on M1.

The drawback of this approach is that the CPU frequency won't be available on M1, but according to the discussions in https://github.com/shirou/gopsutil/issues/1000 and https://github.com/giampaolo/psutil/issues/1892, no definitive solution to this issue has been found yet.