### PR TITLE
Use VERSION_ID instead of VERSION field for platform version

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -181,7 +181,7 @@ func getOSRelease() (platform string, version string, err error) {
 		switch field[0] {
 		case "ID": // use ID for lowercase
 			platform = trimQuotes(field[1])
-		case "VERSION":
+		case "VERSION_ID":
 			version = trimQuotes(field[1])
 		}
 	}


### PR DESCRIPTION
`VERSION` can include release code name, whereas `VERSION_ID` is a simplified identifier containing no spaces (i.e. `VERSION="17 (Beefy Miracle)"`, `VERSION_ID=17`). This makes it much more useful for programmatic usage (specifically, for using version as part of a file path).

If we want the codename in the future, we could always get that from `VERSION_CODENAME` and return that separately.

Edit: This only affects platform information read from the `/etc/os-release` file. When platform data is read from `/etc/lsb-release` (the default location), we get the version information from the `DISTRIB_RELEASE` field, which is already in this simplified format.