### PR TITLE
process: fix dropped errors

### DIFF
--- a/process/process_posix.go
+++ b/process/process_posix.go
@@ -26,6 +26,9 @@ func getTerminalMap() (map[uint64]string, error) {
 	defer d.Close()
 
 	devnames, err := d.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
 	for _, devname := range devnames {
 		if strings.HasPrefix(devname, "/dev/tty") {
 			termfiles = append(termfiles, "/dev/tty/"+devname)
@@ -43,6 +46,9 @@ func getTerminalMap() (map[uint64]string, error) {
 	if ptsnames == nil {
 		defer ptsd.Close()
 		ptsnames, err = ptsd.Readdirnames(-1)
+		if err != nil {
+			return nil, err
+		}
 		for _, ptsname := range ptsnames {
 			termfiles = append(termfiles, "/dev/pts/"+ptsname)
 		}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -84,7 +84,9 @@ func Test_Process_memory_maps(t *testing.T) {
 	checkPid := os.Getpid()
 
 	ret, err := NewProcess(int32(checkPid))
-
+	if err != nil {
+		t.Errorf("new process error %v", err)
+	}
 	mmaps, err := ret.MemoryMaps(false)
 	if err != nil {
 		t.Errorf("memory map get error %v", err)


### PR DESCRIPTION
This picks up three dropped `err` variables in the `process` package.