### PR TITLE
fix: do not read under `/proc/pid/stat` if empty

### DIFF
--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -867,6 +867,9 @@ func (p *Process) fillFromStat() (int32, int32, *cpu.TimesStat, int64, int32, er
 		return 0, 0, nil, 0, 0, err
 	}
 	fields := strings.Fields(string(contents))
+	if len(fields) == 0 {
+		return 0, 0, nil, 0, 0, fmt.Errorf("stat file is empty for pid %d", pid)
+	}
 	timestamp := time.Now().Unix()
 
 	i := 1


### PR DESCRIPTION
Hi all! I have to admit this is a pretty weird issue, but it seems under some conditions, `/proc/pid/stat` could be empty. See the logs below

```
panic: runtime error: index out of range [1] with length 0
goroutine 394 [running]:
github.com/DataDog/gopsutil/process.(*Process).fillFromStat(0x0?)
/builds/.go/pkg/mod/github.com/!data!dog/gopsutil@v1.2.2/process/process_linux.go:873 +0x47a
github.com/DataDog/gopsutil/process.AllProcesses()
/builds/.go/pkg/mod/github.com/!data!dog/gopsutil@v1.2.2/process/process_linux.go:988 +0x673
```

This patch just prevents reading the file when it is empty. I don't believe it is possible to have a file not empty but with the wrong format, so the != 0 check should be enough