### PR TITLE
Use slog logger instead of seelog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/DataDog/gopsutil
 
+go 1.24.0
+
 require (
 	github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705
-	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
-	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705 h1:UUppSQnhf4Yc6xGxSkoQpPhb7RVzuv5Nb1mwJ5VId9s=
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1c8PVE1PubbNx3mjUr09OqWGCs=
-github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -6,18 +6,18 @@ package process
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
-
-	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/host"
@@ -961,63 +961,63 @@ func AllProcesses() (map[int32]*FilledProcess, error) {
 	for _, pid := range pids {
 		p, err := NewProcess(pid)
 		if err != nil {
-			log.Debugf("Unable to create new process %d, it may have gone away: %s", pid, err)
+			slog.Debug("Unable to create new process, it may have gone away", "pid", pid, "error", err)
 			// Skip the rest of the processing because we have no real process.
 			continue
 		}
 		cmdline, err := p.fillSliceFromCmdline()
 		if err != nil {
-			log.Debugf("Unable to read process command line for %d: %s", pid, err)
+			slog.Debug("Unable to read process command line", "pid", pid, "error", err)
 			cmdline = []string{}
 		}
 		if err := p.fillFromStatus(); err != nil {
-			log.Debugf("Unable to fill from /proc/%d/status: %s", pid, err)
+			slog.Debug("Unable to fill from /proc/PID/status", "pid", pid, "error", err)
 		}
 		memInfo, memInfoEx, err := p.readFromStatm()
 		if err != nil {
-			log.Debugf("Unable to fill from /proc/%d/statm: %s", pid, err)
+			slog.Debug("Unable to fill from /proc/PID/statm", "pid", pid, "error", err)
 			memInfo = &MemoryInfoStat{}
 			memInfoEx = &MemoryInfoExStat{}
 		}
 		ioStat, err := p.fillFromIO(user)
 		if os.IsPermission(err) {
-			log.Tracef("Unable to access /proc/%d/io, permission denied", pid)
+			slog.Log(context.Background(), slog.LevelDebug-4, "Unable to access /proc/PID/io, permission denied", "pid", pid)
 			// Without root permissions we can't read for other processes.
 			ioStat = &IOCountersStat{}
 		} else if err != nil {
-			log.Debugf("Unable to access /proc/%d/io: %s", pid, err)
+			slog.Debug("Unable to access /proc/PID/io", "pid", pid, "error", err)
 			ioStat = &IOCountersStat{}
 		}
 		ppid, _, t1, createTime, nice, err := p.fillFromStat()
 		if err != nil {
-			log.Debugf("Unable to fill from /proc/%d/stat: %s", pid, err)
+			slog.Debug("Unable to fill from /proc/PID/stat", "pid", pid, "error", err)
 			t1 = &cpu.TimesStat{}
 		}
 		cwd, err := p.fillFromCwd(user)
 		if os.IsPermission(err) {
 
-			log.Tracef("Unable to access /proc/%d/cwd, permission denied", pid)
+			slog.Log(context.Background(), slog.LevelDebug-4, "Unable to access /proc/PID/cwd, permission denied", "pid", pid)
 			cwd = ""
 		} else if err != nil {
-			log.Debugf("Unable to access /proc/%d/cwd: %s", pid, err)
+			slog.Debug("Unable to access /proc/PID/cwd", "pid", pid, "error", err)
 			cwd = ""
 		}
 		exe, err := p.fillFromExe(user)
 		if os.IsPermission(err) {
 			// Without root permissions we can't read for other processes.
-			log.Tracef("Unable to access /proc/%d/exe, permission denied", pid)
+			slog.Log(context.Background(), slog.LevelDebug-4, "Unable to access /proc/PID/exe, permission denied", "pid", pid)
 			exe = ""
 		} else if err != nil {
-			log.Debugf("Unable to access /proc/%d/exe: %s", pid, err)
+			slog.Debug("Unable to access /proc/PID/exe", "pid", pid, "error", err)
 			exe = ""
 		}
 		openFdCount := int32(-1)
 		_, fds, err := p.fillFromfdList(user)
 		if os.IsPermission(err) {
 			// Without root permissions we can't read for other processes.
-			log.Tracef("Unable to access /proc/%d/fd, permission denied", pid)
+			slog.Log(context.Background(), slog.LevelDebug-4, "Unable to access /proc/PID/fd, permission denied", "pid", pid)
 		} else if err != nil {
-			log.Debugf("Unable to access /proc/%d/fd: %s", pid, err)
+			slog.Debug("Unable to access /proc/PID/fd", "pid", pid, "error", err)
 		} else {
 			openFdCount = int32(len(fds))
 		}

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -1,12 +1,13 @@
+//go:build linux
 // +build linux
 
 package process
 
 import (
+	"log/slog"
 	"os"
 	"testing"
 
-	log "github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +25,7 @@ func BenchmarkLinuxAllProcessesOnPostgresProcFS(b *testing.B) {
 	defer os.Unsetenv("HOST_PROC")
 
 	// Disable logging (as it'll be noisy)
-	log.ReplaceLogger(log.Disabled)
+	slog.SetDefault(slog.New(slog.DiscardHandler))
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -45,7 +46,7 @@ func BenchmarkLinuxAllProcessesOnLocalProcFS(b *testing.B) {
 	errCount := 0
 
 	// Disable logging (as it'll be noisy)
-	log.ReplaceLogger(log.Disabled)
+	slog.SetDefault(slog.New(slog.DiscardHandler))
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package process
@@ -13,10 +14,11 @@ import (
 	"github.com/StackExchange/wmi"
 	"github.com/shirou/w32"
 
+	"log/slog"
+
 	cpu "github.com/DataDog/gopsutil/cpu"
 	"github.com/DataDog/gopsutil/internal/common"
 	net "github.com/DataDog/gopsutil/net"
-	log "github.com/cihub/seelog"
 )
 
 const (
@@ -553,7 +555,7 @@ func get_username_for_process(h syscall.Handle) (name string, err error) {
 	var t syscall.Token
 	err = syscall.OpenProcessToken(h, syscall.TOKEN_QUERY, &t)
 	if err != nil {
-		log.Debugf("Failed to open process token %v", err)
+		slog.Debug("Failed to open process token", "error", err)
 		return
 	}
 	defer t.Close()


### PR DESCRIPTION
We removed the seelog based logger in the agent and use slog instead.