### PR TITLE
Remove duplicated Percent function for uncommon OSes

### DIFF
--- a/cpu/cpu_fallback.go
+++ b/cpu/cpu_fallback.go
@@ -3,8 +3,6 @@
 package cpu
 
 import (
-	"time"
-
 	"github.com/DataDog/gopsutil/internal/common"
 )
 
@@ -14,8 +12,4 @@ func Times(percpu bool) ([]TimesStat, error) {
 
 func Info() ([]InfoStat, error) {
 	return []InfoStat{}, common.ErrNotImplementedError
-}
-
-func Percent(interval time.Duration, percpu bool) ([]float64, error) {
-	return []float64{}, common.ErrNotImplementedError
 }


### PR DESCRIPTION
Remove duplicated Percent function (which has an implementation for all OSes in another file) for uncommon OSes.

The file has build tags `!darwin,!linux,!freebsd,!openbsd,!windows`, so it prevents building for other platforms (eg. AIX). 